### PR TITLE
Remove Auth0's OSS library Gradle plugin

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -22,29 +22,7 @@
  * THE SOFTWARE.
  */
 
-plugins {
-    id "com.auth0.gradle.oss-library.android" version "0.8.0"
-}
-
-logger.lifecycle("Using version ${version} for ${name}")
-
-oss {
-    name 'Auth0.Android'
-    repository 'Auth0.Android'
-    organization 'auth0'
-    description 'Android toolkit for Auth0 API'
-
-    developers {
-        auth0 {
-            displayName = 'Auth0'
-            email = 'oss@auth0.com'
-        }
-        lbalmaceda {
-            displayName = 'Luciano Balmaceda'
-            email = 'luciano.balmaceda@auth0.com'
-        }
-    }
-}
+apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28


### PR DESCRIPTION
This allows us to tag commits with whatever versioning we like (ie. append `-SGx`) and still actually build the thing.